### PR TITLE
Add --rm-before-starting option

### DIFF
--- a/get_ipopt_source.sh
+++ b/get_ipopt_source.sh
@@ -4,9 +4,73 @@
 
 set -e
 
-CMAKE_INSTALL_PREFIX=$1
+if [ $(dirname "$0") != "." ]; then
+    echo "$0: error: must be run from top-level ipopt-mirror directory"
+    exit 1
+fi
 
 IPOPT_VERSION=3.12
+
+if [ "$1" = "--rm-before-starting" ]; then
+    # Remove upstream's top-level files.
+    cat <<EOF | xargs -n1 --verbose rm -f
+.travis.yml
+ChangeLog
+Dependencies
+INSTALL
+LICENSE
+Makefile.am
+Makefile.in
+README
+appveyor.yml
+config.guess
+config.sub
+configure
+configure.ac
+depcomp
+downloaded.ASL
+downloaded.Blas
+downloaded.HSL
+downloaded.Lapack
+downloaded.Metis
+downloaded.Mumps
+install-sh
+ltmain.sh
+missing
+EOF
+    # Remove upstream's top-level directories.
+    cat <<EOF | xargs -n1 --verbose rm -rf
+.svn
+BuildTools
+doxydoc
+Ipopt
+ThirdParty
+EOF
+    # Ensure that only RobotLocomotion-related files exist.
+    touch expected-files existing-files
+cat <<EOF > expected-files
+.
+..
+.git
+.gitignore
+README.md
+existing-files
+expected-files
+get_ipopt_source.sh
+remove-pedantic-errors.diff
+EOF
+    ls -a | LC_ALL=C sort > existing-files
+    diff -U 999 existing-files expected-files
+    rm -f existing-files expected-files
+elif [ -n "$1" ]; then
+    echo "$0: error: unknown argment"
+    exit 1
+fi
+
+if [ -r "configure.ac" ]; then
+    echo "$0: error: checkout is not clean; consider --rm-before-starting"
+    exit 1
+fi
 
 svn checkout --non-interactive --trust-server-cert https://projects.coin-or.org/svn/Ipopt/stable/$IPOPT_VERSION .
 


### PR DESCRIPTION
The get_ipiot_source.sh script does not work from a git checkout; it tries to overwrite files that already exist.  Instead of failing weirdly, we now fail-fast and offer the --rm-before-starting option that nukes the prior files and then rebuilds the tree.  Other than the failure checking and recovery, this is a non-functional change; it does not alter the resulting ipopt-mirror results at all.

This is a portion of RobotLocomotion/drake#4913.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/ipopt-mirror/1)
<!-- Reviewable:end -->
